### PR TITLE
feat: 🚀 支持在KuRootView标签上添加属性，或使用开放标签

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 # Build Outputs
 build
 dist
+.idea

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uni-ku/root",
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "借助 Vite 模拟出虚拟的全局组件，解决 Uniapp 无法使用全局共享组件问题",
   "author": {
     "name": "sKy",

--- a/src/root.ts
+++ b/src/root.ts
@@ -18,9 +18,16 @@ export async function registerKuApp(code: string, fileName: string = 'App.ku') {
 
 export async function rebuildKuApp(code: string) {
   const ms = new MagicString(code)
-  const rootTagNameRE = /<(KuRootView|ku-root-view)\s*\/>/
-
-  ms.replace(rootTagNameRE, '<slot />')
+  // 匹配开放标签
+  ms.replace(
+    /<(KuRootView|ku-root-view)[^>]*>(.*?)<\/\1>/gi,
+    '<slot$2>$3</slot>',
+  )
+  // 匹配自闭和标签
+  ms.replace(
+    /<(KuRootView|ku-root-view)(.*?)\/>/gi,
+    '<slot$2/>',
+  )
 
   const sfc = await parseSFC(code)
   if (sfc.script) {


### PR DESCRIPTION
修改前：
`KuRootView` 的使用存在限制。代码必须严格为`<KuRootView />`，才会起效。

比如当存在条件渲染的情况下必须写成

```js
 <template v-if="app_ready">
    <KuRootView />
  </template>
```
而不是

`<KuRootView v-if="app_ready" />`

修改后：
支持

`<KuRootView v-if="app_ready" class=a />`