### PR TITLE
feat: 实现指定页面排除根组件的功能

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 # Build Outputs
 build
 dist
+.idea

--- a/README.md
+++ b/README.md
@@ -494,6 +494,37 @@ function showToast() {
 
 </details>
 
+<details>
+
+<summary>
+  <strong>(点击展开) 示例四：过滤不需要根组件的页面</strong>
+</summary>
+<br />
+
+> 总会有一些不需要根组件的页面，这时候可以通过 `filterPage` 选项来过滤
+
+```ts
+// vite.config.(js|ts)
+
+import Uni from '@dcloudio/vite-plugin-uni'
+import UniKuRoot from '@uni-ku/root'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [
+    UniKuRoot({
+      // filterPage?: (pagePaths: string[]) => string[]
+      filterPage(pagePaths) {
+        return pagePaths.filter(path => !path.includes('excluded.vue'))
+      },
+    }),
+    Uni()
+  ]
+})
+```
+
+</details>
+
 ### 📝 待办
 
 - [x] 支持热更新

--- a/README.md
+++ b/README.md
@@ -501,7 +501,9 @@ function showToast() {
 </summary>
 <br />
 
-> 总会有一些不需要根组件的页面，这时候可以通过 `filterPage` 选项来过滤
+总会有一些不需要根组件的页面，这时候可以通过 `exclude` 选项来过滤
+
+> 注意：`exclude` 选项支持 glob 模式，等同于 [createFilter](https://cn.vite.dev/guide/api-plugin.html#filtering-include-exclude-pattern)
 
 ```ts
 // vite.config.(js|ts)
@@ -513,10 +515,7 @@ import { defineConfig } from 'vite'
 export default defineConfig({
   plugins: [
     UniKuRoot({
-      // filterPage?: (pagePaths: string[]) => string[]
-      filterPage(pagePaths) {
-        return pagePaths.filter(path => !path.includes('excluded.vue'))
-      },
+      exclude: '**/excluded.vue'
     }),
     Uni()
   ]

--- a/README.md
+++ b/README.md
@@ -251,6 +251,39 @@ onMounted(() => {
 
 </details>
 
+<details>
+
+<summary>
+  <strong>(点击展开) 功能三：过滤掉不需要根组件的页面</strong>
+</summary>
+<br />
+
+如果遇到一些不需要根组件的页面，可以设置 `excludePages` 选项来过滤
+
+> `excludePages` 选项支持采用 glob 模式进行编写
+
+```ts
+// vite.config.(js|ts)
+
+import Uni from '@dcloudio/vite-plugin-uni'
+import UniKuRoot from '@uni-ku/root'
+import { defineConfig } from 'vite'
+
+export default defineConfig({
+  plugins: [
+    UniKuRoot({
+      excludePages: [
+        'src/exclude.vue',
+        'src/exclude/**/*.vue'
+      ],
+    }),
+    Uni()
+  ]
+})
+```
+
+</details>
+
 ### ✨ 例子
 
 > [!TIP]
@@ -490,36 +523,6 @@ function showToast() {
     展示Toast信息
   </WdButton>
 </template>
-```
-
-</details>
-
-<details>
-
-<summary>
-  <strong>(点击展开) 示例四：过滤不需要根组件的页面</strong>
-</summary>
-<br />
-
-总会有一些不需要根组件的页面，这时候可以通过 `exclude` 选项来过滤
-
-> 注意：`exclude` 选项支持 glob 模式，等同于 [createFilter](https://cn.vite.dev/guide/api-plugin.html#filtering-include-exclude-pattern)
-
-```ts
-// vite.config.(js|ts)
-
-import Uni from '@dcloudio/vite-plugin-uni'
-import UniKuRoot from '@uni-ku/root'
-import { defineConfig } from 'vite'
-
-export default defineConfig({
-  plugins: [
-    UniKuRoot({
-      exclude: '**/excluded.vue'
-    }),
-    Uni()
-  ]
-})
 ```
 
 </details>

--- a/examples/src/pages.json
+++ b/examples/src/pages.json
@@ -17,6 +17,12 @@
       "style": {
         "navigationBarTitleText": "uni-app"
       }
+    },
+    {
+      "path": "pages/excluded",
+      "style": {
+        "navigationBarTitleText": "uni-app"
+      }
     }
   ],
   "globalStyle": {

--- a/examples/src/pages/excluded.vue
+++ b/examples/src/pages/excluded.vue
@@ -1,0 +1,42 @@
+<script setup lang="ts">
+import { useToast } from '@/composables/useToast'
+import LayoutDefault from '@/layouts/default.vue'
+import { onMounted, ref } from 'vue'
+
+const { globalToastState, showToast, hideToast } = useToast()
+
+function handleClick() {
+  return globalToastState.value ? hideToast() : showToast()
+}
+
+const uniKuRoot = ref()
+
+onMounted(() => {
+  // eslint-disable-next-line no-console
+  console.log(uniKuRoot.value?.exposeRef)
+})
+
+const color = 'red'
+</script>
+
+<template root="uniKuRoot">
+  <LayoutDefault>
+    <!-- 这行代码仅小程序可见，完全支持 PageMeta -->
+
+    <view>
+      Hello KuRoot
+    </view>
+    <view class="text">
+      Hello v-bind css
+    </view>
+    <button @click="handleClick">
+      展示Toast
+    </button>
+  </LayoutDefault>
+</template>
+
+<style scoped>
+.text {
+  color: v-bind(color)
+}
+</style>

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
     UniKuRoot({
       enabledVirtualHost: false,
       rootFileName: 'KuRoot',
+      filterPage(pagePaths) {
+        return pagePaths.filter(path => !path.includes('excluded.vue'))
+      },
     }),
     Uni(),
   ],

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -12,9 +12,7 @@ export default defineConfig({
     UniKuRoot({
       enabledVirtualHost: false,
       rootFileName: 'KuRoot',
-      filterPage(pagePaths) {
-        return pagePaths.filter(path => !path.includes('excluded.vue'))
-      },
+      exclude: '**/excluded.vue',
     }),
     Uni(),
   ],

--- a/examples/vite.config.ts
+++ b/examples/vite.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
     UniKuRoot({
       enabledVirtualHost: false,
       rootFileName: 'KuRoot',
-      exclude: '**/excluded.vue',
+      excludePages: 'src/pages/excluded.vue',
     }),
     Uni(),
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,9 +29,13 @@ interface UniKuRootOptions {
    */
   rootFileName?: string
   /**
-   * 需要排除的路径模式（glob 格式）
+   * 需要排除根组件的页面，支持 glob 匹配
+   * @example
+   * ```
+   * ['src/pages/some.vue', 'src/exclude/*.vue']
+   * ```
    */
-  exclude?: FilterPattern
+  excludePages?: FilterPattern
 }
 
 export default function UniKuRoot(options: UniKuRootOptions = {
@@ -75,7 +79,7 @@ export default function UniKuRoot(options: UniKuRootOptions = {
 
       const pageId = hasPlatformPlugin ? normalizePlatformPath(id) : id
 
-      const filterPage = createFilter(pagesJson, options.exclude)
+      const filterPage = createFilter(pagesJson, options.excludePages)
       if (filterPage(pageId)) {
         ms = await transformPage(code, options.enabledGlobalRef)
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,10 @@ interface UniKuRootOptions {
    * @default 'App.ku'
    */
   rootFileName?: string
+  /**
+   * 页面过滤钩子
+   */
+  filterPage?: (pagePaths: string[]) => string[]
 }
 
 export default function UniKuRoot(options: UniKuRootOptions = {
@@ -37,7 +41,8 @@ export default function UniKuRoot(options: UniKuRootOptions = {
   const appKuPath = resolve(rootPath, `${options.rootFileName}.vue`)
   const pagesPath = resolve(rootPath, 'pages.json')
 
-  let pagesJson = loadPagesJson(pagesPath, rootPath)
+  let rawPagesJson = loadPagesJson(pagesPath, rootPath)
+  let pagesJson = options.filterPage ? options.filterPage(rawPagesJson) : rawPagesJson
 
   let watcher: FSWatcher | null = null
 
@@ -52,7 +57,8 @@ export default function UniKuRoot(options: UniKuRootOptions = {
     buildStart() {
       watcher = chokidar.watch(pagesPath).on('all', (event) => {
         if (['add', 'change'].includes(event)) {
-          pagesJson = loadPagesJson(pagesPath, rootPath)
+          rawPagesJson = loadPagesJson(pagesPath, rootPath)
+          pagesJson = options.filterPage ? options.filterPage(rawPagesJson) : rawPagesJson
         }
       })
     },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,7 +22,7 @@ export function formatPagePath(root: string, path: string) {
   return normalizePath(`${join(root, path)}.vue`)
 }
 
-export function loadPagesJson(path: string, rootPath: string) {
+export function loadPagesJson(path: string, rootPath: string): string[] {
   const pagesJsonRaw = readFileSync(path, 'utf-8')
 
   const { pages = [], subPackages = [] } = jsonParse(pagesJsonRaw)


### PR DESCRIPTION
总会有一些不需要根组件的页面，增加 `exclude` 选项来过滤掉

```ts
// vite.config.(js|ts)

import Uni from '@dcloudio/vite-plugin-uni'
import UniKuRoot from '@uni-ku/root'
import { defineConfig } from 'vite'

export default defineConfig({
  plugins: [
    UniKuRoot({
      exclude: '**/excluded.vue',
    }),
    Uni()
  ]
})
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable exclude option to filter pages using glob patterns.

* **Documentation**
  * Added examples demonstrating page exclusion (duplicate blocks inserted in README).

* **Examples**
  * Added a sample page and updated example configuration to showcase exclusion behavior.

* **Chores**
  * Updated ignore settings to exclude IDE configuration files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->