### PR TITLE
docs: excludePages 说明补充

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ onMounted(() => {
 ```ts
 // vite.config.(js|ts)
 
+import { fileURLToPath, URL } from 'node:url'
 import Uni from '@dcloudio/vite-plugin-uni'
 import UniKuRoot from '@uni-ku/root'
 import { defineConfig } from 'vite'
@@ -274,7 +275,9 @@ export default defineConfig({
     UniKuRoot({
       excludePages: [
         'src/exclude.vue',
-        'src/exclude/**/*.vue'
+        'src/exclude/**/*.vue',
+        // 在 hbx 项目中指定具体文件时，你可能需要写绝对路径
+        fileURLToPath(new URL('src/exclude.vue', import.meta.url)),
       ],
     }),
     Uni()


### PR DESCRIPTION
我在 hbx 项目中指定具体文件时，使用文件相对路径不起作用，补充绝对路径使用方式

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README vite.config example to include an import from node:url and demonstrate using fileURLToPath to resolve an absolute path in excludePages.
  * Added a note clarifying when absolute paths may be required in certain projects.
  * Retained the existing glob pattern for exclusions, with minor formatting adjustments for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->