### PR TITLE
feat: support nvue pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
 - 自定义虚拟根组件文件命名(App.ku.vue文件命名支持更换)
 - 更高灵活度的获取虚拟根组件实例(获取KuRootView的Ref)
 - 自动提取PageMeta到页面顶层(自动提升小程序PageMeta[用于阻止滚动穿透]组件)
+- 支持 nvue 页面使用虚拟根组件
 
 ### 📦 安装
 
@@ -287,6 +288,27 @@ export default defineConfig({
 
 </details>
 
+<details>
+
+<summary>
+  <strong>(点击展开) 功能四：支持 nvue 页面</strong>
+</summary>
+<br />
+
+Root 会识别 `pages.json` 中对应的 `.nvue` 页面，并在页面内本地引入虚拟根组件进行包裹。由于 nvue 页面不依赖 Vue 全局组件注册，插件会自动把 `App.ku.vue` 作为局部组件注入到 nvue 页面中。
+
+支持特性：
+
+- `pages.json` 中未写扩展名时，会同时匹配已存在的 `.vue` 与 `.nvue` 页面文件
+- nvue 页面会被 `<GlobalKuRoot>` 包裹，效果与普通页面的 `<global-ku-root>` 对齐
+- `PageMeta` / `page-meta` 会继续自动提取到页面顶层
+- `template root="uniKuRoot"` 与 `enabledGlobalRef` 仍然生效
+
+> [!Note]
+> 如果 `App.ku.vue` 需要包裹 nvue 页面，请确保其中使用 nvue 支持的组件与样式。组件库主题、原生导航栏、TabBar 等平台特定逻辑建议放在业务或组件库自身运行时中处理。
+
+</details>
+
 ### ✨ 例子
 
 > [!TIP]
@@ -535,6 +557,7 @@ function showToast() {
 - [x] 支持热更新
 - [x] 支持VueSFC
 - [x] 支持小程序PageMeta
+- [x] 支持 nvue 页面
 - [ ] 支持 App.ku.vue 内直接编写控制逻辑
 - [ ] 补全单元测试
 

--- a/README.md
+++ b/README.md
@@ -288,27 +288,6 @@ export default defineConfig({
 
 </details>
 
-<details>
-
-<summary>
-  <strong>(点击展开) 功能四：支持 nvue 页面</strong>
-</summary>
-<br />
-
-Root 会识别 `pages.json` 中对应的 `.nvue` 页面，并在页面内本地引入虚拟根组件进行包裹。由于 nvue 页面不依赖 Vue 全局组件注册，插件会自动把 `App.ku.vue` 作为局部组件注入到 nvue 页面中。
-
-支持特性：
-
-- `pages.json` 中未写扩展名时，会同时匹配已存在的 `.vue` 与 `.nvue` 页面文件
-- nvue 页面会被 `<GlobalKuRoot>` 包裹，效果与普通页面的 `<global-ku-root>` 对齐
-- `PageMeta` / `page-meta` 会继续自动提取到页面顶层
-- `template root="uniKuRoot"` 与 `enabledGlobalRef` 仍然生效
-
-> [!Note]
-> 如果 `App.ku.vue` 需要包裹 nvue 页面，请确保其中使用 nvue 支持的组件与样式。组件库主题、原生导航栏、TabBar 等平台特定逻辑建议放在业务或组件库自身运行时中处理。
-
-</details>
-
 ### ✨ 例子
 
 > [!TIP]
@@ -558,7 +537,6 @@ function showToast() {
 - [x] 支持VueSFC
 - [x] 支持小程序PageMeta
 - [x] 支持 nvue 页面
-- [ ] 支持 App.ku.vue 内直接编写控制逻辑
 - [ ] 补全单元测试
 
 ### 🤔 与uni-helper-layouts的区别

--- a/examples/package.json
+++ b/examples/package.json
@@ -6,10 +6,14 @@
     "dev": "uni",
     "build": "uni build",
     "dev:mp-weixin": "uni -p mp-weixin",
-    "build:mp-weixin": "uni build -p mp-weixin"
+    "build:mp-weixin": "uni build -p mp-weixin",
+    "dev:app": "uni -p app",
+    "build:app": "uni build -p app"
   },
   "dependencies": {
     "@dcloudio/uni-app": "3.0.0-4040520250104002",
+    "@dcloudio/uni-app-plus": "3.0.0-4040520250104002",
+    "@dcloudio/uni-app-vite": "3.0.0-4040520250104002",
     "@dcloudio/uni-components": "3.0.0-4040520250104002",
     "@dcloudio/uni-h5": "3.0.0-4040520250104002",
     "@dcloudio/uni-mp-weixin": "3.0.0-4040520250104002",

--- a/examples/src/KuRoot.vue
+++ b/examples/src/KuRoot.vue
@@ -12,8 +12,8 @@ defineExpose({
 </script>
 
 <template>
-  <div>Hello AppKuVue</div>
+  <view>Hello AppKuVue</view>
   <KuRootView />
-  <div>{{ HelloVueRef }}</div>
+  <view>{{ HelloVueRef }}</view>
   <GlobalToast />
 </template>

--- a/examples/src/components/GlobalToast.vue
+++ b/examples/src/components/GlobalToast.vue
@@ -5,11 +5,11 @@ const { globalToastState, hideToast } = useToast()
 </script>
 
 <template>
-  <div v-if="globalToastState" class="toast-wrapper" @click="hideToast">
-    <div class="toast-box">
+  <view v-if="globalToastState" class="toast-wrapper" @click="hideToast">
+    <view class="toast-box">
       welcome to use @uni-ku/root
-    </div>
-  </div>
+    </view>
+  </view>
 </template>
 
 <style scoped>

--- a/examples/src/layouts/default.vue
+++ b/examples/src/layouts/default.vue
@@ -1,6 +1,6 @@
 <template>
-  <div>
+  <view>
     <slot />
     Default Layout
-  </div>
+  </view>
 </template>

--- a/examples/src/pages.json
+++ b/examples/src/pages.json
@@ -23,6 +23,18 @@
       "style": {
         "navigationBarTitleText": "uni-app"
       }
+    },
+    {
+      "path": "pages/nvue-demo",
+      "style": {
+        "navigationBarTitleText": "nvue demo"
+      }
+    },
+    {
+      "path": "pages/nvue-options",
+      "style": {
+        "navigationBarTitleText": "nvue options"
+      }
     }
   ],
   "globalStyle": {

--- a/examples/src/pages/index.vue
+++ b/examples/src/pages/index.vue
@@ -9,6 +9,14 @@ function handleClick() {
   return globalToastState.value ? hideToast() : showToast()
 }
 
+function goNvueDemo() {
+  uni.navigateTo({ url: '/pages/nvue-demo' })
+}
+
+function goNvueOptions() {
+  uni.navigateTo({ url: '/pages/nvue-options' })
+}
+
 const uniKuRoot = ref()
 
 onMounted(() => {
@@ -31,6 +39,12 @@ const color = 'red'
     </view>
     <button @click="handleClick">
       展示Toast
+    </button>
+    <button @click="goNvueDemo">
+      打开 NVUE Demo
+    </button>
+    <button @click="goNvueOptions">
+      打开 NVUE Options
     </button>
   </LayoutDefault>
 </template>

--- a/examples/src/pages/nvue-demo.nvue
+++ b/examples/src/pages/nvue-demo.nvue
@@ -1,0 +1,39 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+
+const pageLabel = ref('Hello NVUE + UniKuRoot')
+const uniKuRoot = ref()
+
+onMounted(() => {
+  // eslint-disable-next-line no-console
+  console.log('[nvue-demo] exposeRef from KuRoot:', uniKuRoot.value?.exposeRef)
+})
+</script>
+
+<template root="uniKuRoot">
+  <view class="page">
+    <text class="title">{{ pageLabel }}</text>
+    <text class="hint">This page is .nvue and should be wrapped by local GlobalKuRoot.</text>
+    <text class="hint">Check console for KuRoot exposeRef after mount.</text>
+  </view>
+</template>
+
+<style>
+.page {
+  flex: 1;
+  padding: 24px;
+  background-color: #f8f8f8;
+}
+
+.title {
+  font-size: 20px;
+  color: #111111;
+  margin-bottom: 12px;
+}
+
+.hint {
+  font-size: 14px;
+  color: #666666;
+  margin-bottom: 8px;
+}
+</style>

--- a/examples/src/pages/nvue-options.nvue
+++ b/examples/src/pages/nvue-options.nvue
@@ -1,0 +1,35 @@
+<template root="kuRoot">
+  <view class="page">
+    <text class="title">{{ title }}</text>
+    <text class="hint">Options API nvue page with local GlobalKuRoot registration.</text>
+  </view>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      title: 'Hello NVUE Options API',
+    }
+  },
+}
+</script>
+
+<style>
+.page {
+  flex: 1;
+  padding: 24px;
+  background-color: #ffffff;
+}
+
+.title {
+  font-size: 20px;
+  color: #111111;
+  margin-bottom: 12px;
+}
+
+.hint {
+  font-size: 14px;
+  color: #666666;
+}
+</style>

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "example:build:h5": "pnpm build && pnpm -C examples run build",
     "example:dev:mp-weixin": "pnpm build && pnpm -C examples run dev:mp-weixin",
     "example:build:mp-weixin": "pnpm build && pnpm -C examples run build:mp-weixin",
+    "example:verify:nvue": "vitest run test/examples-nvue.test.ts",
     "prepare": "simple-git-hooks",
     "lint": "eslint . --fix",
     "prepublishOnly": "pnpm build"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,12 @@ importers:
       '@dcloudio/uni-app':
         specifier: 3.0.0-4040520250104002
         version: 3.0.0-4040520250104002(@dcloudio/types@3.4.21)(postcss@8.5.6)(rollup@4.52.0)(vue@3.5.21(typescript@5.9.2))
+      '@dcloudio/uni-app-plus':
+        specifier: 3.0.0-4040520250104002
+        version: 3.0.0-4040520250104002(postcss@8.5.6)(rollup@4.52.0)(vite@5.2.1(@types/node@24.7.0)(terser@5.44.0))(vue@3.5.21(typescript@5.9.2))
+      '@dcloudio/uni-app-vite':
+        specifier: 3.0.0-4040520250104002
+        version: 3.0.0-4040520250104002(postcss@8.5.6)(rollup@4.52.0)(vite@5.2.1(@types/node@24.7.0)(terser@5.44.0))(vue@3.5.21(typescript@5.9.2))
       '@dcloudio/uni-components':
         specifier: 3.0.0-4040520250104002
         version: 3.0.0-4040520250104002(postcss@8.5.6)(rollup@4.52.0)(vue@3.5.21(typescript@5.9.2))
@@ -827,6 +833,18 @@ packages:
   '@dcloudio/types@3.4.21':
     resolution: {integrity: sha512-rsv3XfAaD/dtuVboPeYh+vPcULnWyozGaGKHWyN0dYRm7L1uypFUM30qNYMj9iNmbAENuBjV177S1gNEBIvdDA==}
 
+  '@dcloudio/uni-app-plus@3.0.0-4040520250104002':
+    resolution: {integrity: sha512-skRBNw1LZQdQdXGFoPaDlo4Baq27k4yAb2LHeVbbJS0Rx8aRSe7ePuy1NeBomCTAQuOJqA+ZAbyVD6yZSNINFw==}
+
+  '@dcloudio/uni-app-uts@3.0.0-4040520250104002':
+    resolution: {integrity: sha512-+HZ6cZsmpWeKHvgTHiFUZP2vFLFoDkp4wwbTYk/ZwEUAkYVMtlCoz+CfWCvfNhBPj5bGDPGJauL1/Zf/zv7pmQ==}
+
+  '@dcloudio/uni-app-vite@3.0.0-4040520250104002':
+    resolution: {integrity: sha512-PxmTt0e3J8P1mCxFzRRlyltC0h4/bVI2KvnFEuoepVk7yUapl8El+yw5ZaEmBMi/fhySlE5yUQJkTrirvUF8wg==}
+
+  '@dcloudio/uni-app-vue@3.0.0-4040520250104002':
+    resolution: {integrity: sha512-wBsuDOzE3ymT0G61fiCcG1l5kvQtCl7r0PVF/FT//fALuc3l9UbV4ZXNvkwUlhezPJVWtcYQX3p+1m4nTkZt5Q==}
+
   '@dcloudio/uni-app@3.0.0-4040520250104002':
     resolution: {integrity: sha512-t6uewI90Yeuf3BQJF2Qk/NnDiPzYL1aoIeNXF4RCM282WyZGPAr5Kj+uqajaMAbLcOfZgmHqjWDRoSUzDSFpEg==}
     peerDependencies:
@@ -874,6 +892,9 @@ packages:
 
   '@dcloudio/uni-mp-weixin@3.0.0-4040520250104002':
     resolution: {integrity: sha512-6UH4FNTqwh/Y5ZQ9fKmCRiaFy7BAOBfsQz2Pilay0TtScvz4em9mE688VVhuwhbvLHnmHSbiu6cPEUGgMb1Svw==}
+
+  '@dcloudio/uni-nvue-styler@3.0.0-4040520250104002':
+    resolution: {integrity: sha512-So6+GEOPcODJrjdY4aD5xUVOdEFRdQxxlwV0WNwvqJAP5xEb3WyeaEdmWsHo5yB50qkcSoCLXi13N/y0x0hAIw==}
 
   '@dcloudio/uni-push@3.0.0-4040520250104002':
     resolution: {integrity: sha512-ph2gii/AEmh42Ch4QwO/rv7oVDMhg88JnBDdg8KNLCwMY/WUTdYn3EUEuyOFP+pkVFyHk2YJ8rD2pwCmcjSfYw==}
@@ -1796,56 +1817,67 @@ packages:
     resolution: {integrity: sha512-aL6hRwu0k7MTUESgkg7QHY6CoqPgr6gdQXRJI1/VbFlUMwsSzPGSR7sG5d+MCbYnJmJwThc2ol3nixj1fvI/zQ==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.0':
     resolution: {integrity: sha512-BTs0M5s1EJejgIBJhCeiFo7GZZ2IXWkFGcyZhxX4+8usnIo5Mti57108vjXFIQmmJaRyDwmV59Tw64Ap1dkwMw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.0':
     resolution: {integrity: sha512-uj672IVOU9m08DBGvoPKPi/J8jlVgjh12C9GmjjBxCTQc3XtVmRkRKyeHSmIKQpvJ7fIm1EJieBUcnGSzDVFyw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.0':
     resolution: {integrity: sha512-/+IVbeDMDCtB/HP/wiWsSzduD10SEGzIZX2945KSgZRNi4TSkjHqRJtNTVtVb8IRwhJ65ssI56krlLik+zFWkw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.0':
     resolution: {integrity: sha512-U1vVzvSWtSMWKKrGoROPBXMh3Vwn93TA9V35PldokHGqiUbF6erSzox/5qrSMKp6SzakvyjcPiVF8yB1xKr9Pg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.0':
     resolution: {integrity: sha512-X/4WfuBAdQRH8cK3DYl8zC00XEE6aM472W+QCycpQJeLWVnHfkv7RyBFVaTqNUMsTgIX8ihMjCvFF9OUgeABzw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.0':
     resolution: {integrity: sha512-xIRYc58HfWDBZoLmWfWXg2Sq8VCa2iJ32B7mqfWnkx5mekekl0tMe7FHpY8I72RXEcUkaWawRvl3qA55og+cwQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.0':
     resolution: {integrity: sha512-mbsoUey05WJIOz8U1WzNdf+6UMYGwE3fZZnQqsM22FZ3wh1N887HT6jAOjXs6CNEK3Ntu2OBsyQDXfIjouI4dw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.0':
     resolution: {integrity: sha512-qP6aP970bucEi5KKKR4AuPFd8aTx9EF6BvutvYxmZuWLJHmnq4LvBfp0U+yFDMGwJ+AIJEH5sIP+SNypauMWzg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.0':
     resolution: {integrity: sha512-nmSVN+F2i1yKZ7rJNKO3G7ZzmxJgoQBQZ/6c4MuS553Grmr7WqR7LLDcYG53Z2m9409z3JLt4sCOhLdbKQ3HmA==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.0':
     resolution: {integrity: sha512-2d0qRo33G6TfQVjaMR71P+yJVGODrt5V6+T0BDYH4EMfGgdC/2HWDVjSSFw888GSzAZUwuska3+zxNUCDco6rQ==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.0':
     resolution: {integrity: sha512-A1JalX4MOaFAAyGgpO7XP5khquv/7xKzLIyLmhNrbiCxWpMlnsTYr8dnsWM7sEeotNmxvSOEL7F65j0HXFcFsw==}
@@ -2061,41 +2093,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -2218,6 +2258,10 @@ packages:
 
   '@vue/compiler-ssr@3.5.21':
     resolution: {integrity: sha512-vKQ5olH5edFZdf5ZrlEgSO1j1DMA4u23TVK5XR1uMhvwnYvVdDF0nHXJUblL/GvzlShQbjhZZ2uvYmDlAbgo9w==}
+
+  '@vue/consolidate@1.0.0':
+    resolution: {integrity: sha512-oTyUE+QHIzLw2PpV14GD/c7EohDyP64xCniWTcqcEmTd699eFqTIwOmtDYjcO1j3QgdXoJEoWv1/cCdLrRoOfg==}
+    engines: {node: '>= 0.12.0'}
 
   '@vue/devtools-api@6.6.4':
     resolution: {integrity: sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==}
@@ -2784,8 +2828,26 @@ packages:
     peerDependencies:
       postcss: ^8.0.9
 
+  css-font-size-keywords@1.0.0:
+    resolution: {integrity: sha512-Q+svMDbMlelgCfH/RVDKtTDaf5021O486ZThQPIpahnIjUkMUslC+WuOQSWTgGSrNCH08Y7tYNEmmy0hkfMI8Q==}
+
+  css-font-stretch-keywords@1.0.1:
+    resolution: {integrity: sha512-KmugPO2BNqoyp9zmBIUGwt58UQSfyk1X5DbOlkb2pckDXFSAfjsD5wenb88fNrD6fvS+vu90a/tsPpb9vb0SLg==}
+
+  css-font-style-keywords@1.0.1:
+    resolution: {integrity: sha512-0Fn0aTpcDktnR1RzaBYorIxQily85M2KXRpzmxQPgh8pxUN9Fcn00I8u9I3grNr1QXVgCl9T5Imx0ZwKU973Vg==}
+
+  css-font-weight-keywords@1.0.0:
+    resolution: {integrity: sha512-5So8/NH+oDD+EzsnF4iaG4ZFHQ3vaViePkL1ZbZ5iC/KrsCY+WHq/lvOgrtmuOQ9pBBZ1ADGpaf+A4lj1Z9eYA==}
+
+  css-list-helpers@2.0.0:
+    resolution: {integrity: sha512-9Bj8tZ0jWbAM3u/U6m/boAzAwLPwtjzFvwivr2piSvyVa3K3rChJzQy4RIHkNkKiZCHrEMWDJWtTR8UyVhdDnQ==}
+
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
+  css-system-font-keywords@1.0.0:
+    resolution: {integrity: sha512-1umTtVd/fXS25ftfjB71eASCrYhilmEsvDEI6wG/QplnmlfmVM5HkZ/ZX46DT5K3eblFPgLUHt5BRCb0YXkSFA==}
 
   css-tree@2.2.1:
     resolution: {integrity: sha512-OA0mILzGc1kCOCSJerOeqDxDQ4HOh+G8NbOJFOTgOCzpw7fCBubk0fEyxp8AgOL/jvLgYA/uV0cMbe43ElF1JA==}
@@ -4640,6 +4702,9 @@ packages:
   parse-bmfont-xml@1.1.6:
     resolution: {integrity: sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==}
 
+  parse-css-font@4.0.0:
+    resolution: {integrity: sha512-lnY7dTUfjRXsSo5G5C639L8RaBBaVSgL+5hacIFKsNHzeCJQ5SFSZv1DZmc7+wZv/22PFGOq2YbaEHLdaCS/mQ==}
+
   parse-gitignore@2.0.0:
     resolution: {integrity: sha512-RmVuCHWsfu0QPNW+mraxh/xjQVw/lhUCUru8Zni3Ctq3AoMhpDTq0OVdKS6iesd6Kqb7viCV3isAL43dciOSog==}
     engines: {node: '>=14'}
@@ -5683,6 +5748,9 @@ packages:
     resolution: {integrity: sha512-4/u/j4FrCKdi17jaxuJA0jClGxB1AvU2hw/IuayPc4ay1XGaJs/rbb4v5WKwAjNifjmXK9PIFyuPiaK8azyR9w==}
     engines: {node: '>=14.0.0'}
 
+  unquote@1.1.1:
+    resolution: {integrity: sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg==}
+
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
@@ -5827,6 +5895,7 @@ packages:
 
   whatwg-encoding@1.0.5:
     resolution: {integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@2.3.0:
     resolution: {integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==}
@@ -6909,6 +6978,83 @@ snapshots:
 
   '@dcloudio/types@3.4.21': {}
 
+  '@dcloudio/uni-app-plus@3.0.0-4040520250104002(postcss@8.5.6)(rollup@4.52.0)(vite@5.2.1(@types/node@24.7.0)(terser@5.44.0))(vue@3.5.21(typescript@5.9.2))':
+    dependencies:
+      '@dcloudio/uni-app-uts': 3.0.0-4040520250104002(postcss@8.5.6)(rollup@4.52.0)(vue@3.5.21(typescript@5.9.2))
+      '@dcloudio/uni-app-vite': 3.0.0-4040520250104002(postcss@8.5.6)(rollup@4.52.0)(vite@5.2.1(@types/node@24.7.0)(terser@5.44.0))(vue@3.5.21(typescript@5.9.2))
+      '@dcloudio/uni-app-vue': 3.0.0-4040520250104002
+      debug: 4.4.3
+      fs-extra: 10.1.0
+      licia: 1.48.0
+      postcss-selector-parser: 6.1.2
+    transitivePeerDependencies:
+      - '@nuxt/kit'
+      - '@vueuse/core'
+      - postcss
+      - rollup
+      - supports-color
+      - ts-node
+      - vite
+      - vue
+
+  '@dcloudio/uni-app-uts@3.0.0-4040520250104002(postcss@8.5.6)(rollup@4.52.0)(vue@3.5.21(typescript@5.9.2))':
+    dependencies:
+      '@babel/parser': 7.28.4
+      '@babel/types': 7.28.4
+      '@dcloudio/uni-cli-shared': 3.0.0-4040520250104002(postcss@8.5.6)(rollup@4.52.0)(vue@3.5.21(typescript@5.9.2))
+      '@dcloudio/uni-i18n': 3.0.0-4040520250104002
+      '@dcloudio/uni-nvue-styler': 3.0.0-4040520250104002
+      '@dcloudio/uni-shared': 3.0.0-4040520250104002
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
+      '@vue/compiler-core': 3.4.21
+      '@vue/compiler-dom': 3.4.21
+      '@vue/compiler-sfc': 3.4.21
+      '@vue/consolidate': 1.0.0
+      '@vue/shared': 3.4.21
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      estree-walker: 2.0.2
+      fs-extra: 10.1.0
+      magic-string: 0.30.19
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+      unimport: 3.14.6(rollup@4.52.0)
+    transitivePeerDependencies:
+      - '@nuxt/kit'
+      - '@vueuse/core'
+      - postcss
+      - rollup
+      - supports-color
+      - ts-node
+      - vue
+
+  '@dcloudio/uni-app-vite@3.0.0-4040520250104002(postcss@8.5.6)(rollup@4.52.0)(vite@5.2.1(@types/node@24.7.0)(terser@5.44.0))(vue@3.5.21(typescript@5.9.2))':
+    dependencies:
+      '@dcloudio/uni-cli-shared': 3.0.0-4040520250104002(postcss@8.5.6)(rollup@4.52.0)(vue@3.5.21(typescript@5.9.2))
+      '@dcloudio/uni-i18n': 3.0.0-4040520250104002
+      '@dcloudio/uni-nvue-styler': 3.0.0-4040520250104002
+      '@dcloudio/uni-shared': 3.0.0-4040520250104002
+      '@rollup/pluginutils': 5.3.0(rollup@4.52.0)
+      '@vitejs/plugin-vue': 5.1.0(vite@5.2.1(@types/node@24.7.0)(terser@5.44.0))(vue@3.5.21(typescript@5.9.2))
+      '@vue/compiler-dom': 3.4.21
+      '@vue/compiler-sfc': 3.4.21
+      debug: 4.4.3
+      fs-extra: 10.1.0
+      picocolors: 1.1.1
+    transitivePeerDependencies:
+      - '@nuxt/kit'
+      - '@vueuse/core'
+      - postcss
+      - rollup
+      - supports-color
+      - ts-node
+      - vite
+      - vue
+
+  '@dcloudio/uni-app-vue@3.0.0-4040520250104002': {}
+
   '@dcloudio/uni-app@3.0.0-4040520250104002(@dcloudio/types@3.4.21)(postcss@8.5.6)(rollup@4.52.0)(vue@3.5.21(typescript@5.9.2))':
     dependencies:
       '@dcloudio/types': 3.4.21
@@ -7178,6 +7324,11 @@ snapshots:
       - ts-node
       - utf-8-validate
       - vue
+
+  '@dcloudio/uni-nvue-styler@3.0.0-4040520250104002':
+    dependencies:
+      parse-css-font: 4.0.0
+      postcss: 8.5.6
 
   '@dcloudio/uni-push@3.0.0-4040520250104002(postcss@8.5.6)(rollup@4.52.0)(vue@3.5.21(typescript@5.9.2))':
     dependencies:
@@ -8638,6 +8789,8 @@ snapshots:
       '@vue/compiler-dom': 3.5.21
       '@vue/shared': 3.5.21
 
+  '@vue/consolidate@1.0.0': {}
+
   '@vue/devtools-api@6.6.4': {}
 
   '@vue/reactivity@3.5.21':
@@ -9242,6 +9395,16 @@ snapshots:
     dependencies:
       postcss: 8.5.6
 
+  css-font-size-keywords@1.0.0: {}
+
+  css-font-stretch-keywords@1.0.1: {}
+
+  css-font-style-keywords@1.0.1: {}
+
+  css-font-weight-keywords@1.0.0: {}
+
+  css-list-helpers@2.0.0: {}
+
   css-select@5.2.2:
     dependencies:
       boolbase: 1.0.0
@@ -9249,6 +9412,8 @@ snapshots:
       domhandler: 5.0.3
       domutils: 3.2.2
       nth-check: 2.1.1
+
+  css-system-font-keywords@1.0.0: {}
 
   css-tree@2.2.1:
     dependencies:
@@ -11647,6 +11812,16 @@ snapshots:
       xml-parse-from-string: 1.0.1
       xml2js: 0.5.0
 
+  parse-css-font@4.0.0:
+    dependencies:
+      css-font-size-keywords: 1.0.0
+      css-font-stretch-keywords: 1.0.1
+      css-font-style-keywords: 1.0.1
+      css-font-weight-keywords: 1.0.0
+      css-list-helpers: 2.0.0
+      css-system-font-keywords: 1.0.0
+      unquote: 1.1.1
+
   parse-gitignore@2.0.0: {}
 
   parse-headers@2.0.6: {}
@@ -12664,6 +12839,8 @@ snapshots:
     dependencies:
       acorn: 8.15.0
       webpack-virtual-modules: 0.6.2
+
+  unquote@1.1.1: {}
 
   unrs-resolver@1.11.1:
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import type { MagicString } from '@vue/compiler-sfc'
 import type { FSWatcher } from 'chokidar'
 import type { Plugin } from 'vite'
 
-import { dirname, relative, resolve } from 'node:path'
+import { resolve } from 'node:path'
 import process from 'node:process'
 
 import chokidar from 'chokidar'
@@ -10,7 +10,7 @@ import { createFilter, normalizePath } from 'vite'
 
 import { transformNvuePage, transformPage } from './page'
 import { rebuildKuApp, registerKuApp } from './root'
-import { loadPagesJson, normalizePlatformPath, toArray } from './utils'
+import { getRelativePath, loadPagePaths, normalizePlatformPath, toArray } from './utils'
 
 interface UniKuRootOptions {
   /**
@@ -24,7 +24,7 @@ interface UniKuRootOptions {
    */
   enabledGlobalRef?: boolean
   /**
-   * 根文件名
+   * 根文件名，注意不要携带 .vue
    * @default 'App.ku'
    */
   rootFileName?: string
@@ -46,9 +46,8 @@ export default function UniKuRoot(options?: UniKuRootOptions): Plugin {
     ...options,
   }
 
-  const rootFileName = String(options.rootFileName || 'App.ku').replace(/\.vue$/i, '')
   const rootPath = normalizePath(process.env.UNI_INPUT_DIR || resolve(process.env.INIT_CWD || process.cwd(), 'src'))
-  const appKuPath = normalizePath(resolve(rootPath, `${rootFileName}.vue`))
+  const appKuPath = normalizePath(resolve(rootPath, `${options.rootFileName}.vue`))
   const pagesPath = normalizePath(resolve(rootPath, 'pages.json'))
   const excludedPaths = toArray(options.excludePages).filter(Boolean).map(path => normalizePath(resolve(rootPath, path!)))
   const mainFiles = [
@@ -56,15 +55,7 @@ export default function UniKuRoot(options?: UniKuRootOptions): Plugin {
     normalizePath(resolve(rootPath, 'main.js')),
   ]
 
-  const getRelativeImportPath = (fromFile: string, toFile: string) => {
-    let importPath = normalizePath(relative(dirname(fromFile), toFile))
-    if (!importPath.startsWith('.')) {
-      importPath = `./${importPath}`
-    }
-    return importPath
-  }
-
-  let pagesJson = loadPagesJson(pagesPath, rootPath)
+  let pagePaths = loadPagePaths(pagesPath, rootPath)
 
   let watcher: FSWatcher | null = null
 
@@ -79,31 +70,29 @@ export default function UniKuRoot(options?: UniKuRootOptions): Plugin {
     buildStart() {
       watcher = chokidar.watch(pagesPath).on('all', (event) => {
         if (['add', 'change'].includes(event)) {
-          pagesJson = loadPagesJson(pagesPath, rootPath)
+          pagePaths = loadPagePaths(pagesPath, rootPath)
         }
       })
     },
     async transform(code, id) {
       let ms: MagicString | null = null
-      const isSfcBlock = id.includes('?')
-      const cleanId = normalizePath(id.split('?')[0])
 
       const filterMain = createFilter(mainFiles)
-      if (filterMain(cleanId)) {
-        ms = await registerKuApp(code, rootFileName)
+      if (filterMain(id)) {
+        ms = await registerKuApp(code, options.rootFileName)
       }
 
       const filterKuRoot = createFilter(appKuPath)
-      if (filterKuRoot(cleanId)) {
+      if (filterKuRoot(id)) {
         ms = await rebuildKuApp(code, options.enabledVirtualHost)
       }
 
-      const pageId = hasPlatformPlugin ? normalizePlatformPath(cleanId) : cleanId
+      const pageId = hasPlatformPlugin ? normalizePlatformPath(id) : id
 
-      const filterPage = createFilter(pagesJson, excludedPaths)
-      if (!isSfcBlock && filterPage(pageId)) {
-        ms = cleanId.endsWith('.nvue')
-          ? await transformNvuePage(code, getRelativeImportPath(cleanId, appKuPath), options.enabledGlobalRef)
+      const filterPage = createFilter(pagePaths, excludedPaths)
+      if (filterPage(pageId)) {
+        ms = id.endsWith('.nvue')
+          ? await transformNvuePage(code, getRelativePath(id, appKuPath), options.enabledGlobalRef)
           : await transformPage(code, options.enabledGlobalRef)
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,13 @@ import type { MagicString } from '@vue/compiler-sfc'
 import type { FSWatcher } from 'chokidar'
 import type { Plugin } from 'vite'
 
-import { resolve } from 'node:path'
+import { dirname, relative, resolve } from 'node:path'
 import process from 'node:process'
 
 import chokidar from 'chokidar'
-import { createFilter } from 'vite'
+import { createFilter, normalizePath } from 'vite'
 
-import { transformPage } from './page'
+import { transformNvuePage, transformPage } from './page'
 import { rebuildKuApp, registerKuApp } from './root'
 import { loadPagesJson, normalizePlatformPath, toArray } from './utils'
 
@@ -46,10 +46,23 @@ export default function UniKuRoot(options?: UniKuRootOptions): Plugin {
     ...options,
   }
 
-  const rootPath = process.env.UNI_INPUT_DIR || (`${process.env.INIT_CWD}\\src`)
-  const appKuPath = resolve(rootPath, `${options.rootFileName}.vue`)
-  const pagesPath = resolve(rootPath, 'pages.json')
-  const excludedPaths = toArray(options.excludePages).filter(Boolean).map(path => resolve(rootPath, path!))
+  const rootFileName = String(options.rootFileName || 'App.ku').replace(/\.vue$/i, '')
+  const rootPath = normalizePath(process.env.UNI_INPUT_DIR || resolve(process.env.INIT_CWD || process.cwd(), 'src'))
+  const appKuPath = normalizePath(resolve(rootPath, `${rootFileName}.vue`))
+  const pagesPath = normalizePath(resolve(rootPath, 'pages.json'))
+  const excludedPaths = toArray(options.excludePages).filter(Boolean).map(path => normalizePath(resolve(rootPath, path!)))
+  const mainFiles = [
+    normalizePath(resolve(rootPath, 'main.ts')),
+    normalizePath(resolve(rootPath, 'main.js')),
+  ]
+
+  const getRelativeImportPath = (fromFile: string, toFile: string) => {
+    let importPath = normalizePath(relative(dirname(fromFile), toFile))
+    if (!importPath.startsWith('.')) {
+      importPath = `./${importPath}`
+    }
+    return importPath
+  }
 
   let pagesJson = loadPagesJson(pagesPath, rootPath)
 
@@ -72,25 +85,26 @@ export default function UniKuRoot(options?: UniKuRootOptions): Plugin {
     },
     async transform(code, id) {
       let ms: MagicString | null = null
+      const isSfcBlock = id.includes('?')
+      const cleanId = normalizePath(id.split('?')[0])
 
-      const filterMain = createFilter([
-        `${rootPath}/main.ts`,
-        `${rootPath}/main.js`,
-      ])
-      if (filterMain(id)) {
-        ms = await registerKuApp(code, options.rootFileName)
+      const filterMain = createFilter(mainFiles)
+      if (filterMain(cleanId)) {
+        ms = await registerKuApp(code, rootFileName)
       }
 
       const filterKuRoot = createFilter(appKuPath)
-      if (filterKuRoot(id)) {
+      if (filterKuRoot(cleanId)) {
         ms = await rebuildKuApp(code, options.enabledVirtualHost)
       }
 
-      const pageId = hasPlatformPlugin ? normalizePlatformPath(id) : id
+      const pageId = hasPlatformPlugin ? normalizePlatformPath(cleanId) : cleanId
 
       const filterPage = createFilter(pagesJson, excludedPaths)
-      if (filterPage(pageId)) {
-        ms = await transformPage(code, options.enabledGlobalRef)
+      if (!isSfcBlock && filterPage(pageId)) {
+        ms = cleanId.endsWith('.nvue')
+          ? await transformNvuePage(code, getRelativeImportPath(cleanId, appKuPath), options.enabledGlobalRef)
+          : await transformPage(code, options.enabledGlobalRef)
       }
 
       if (ms) {

--- a/src/page.ts
+++ b/src/page.ts
@@ -3,6 +3,37 @@ import { MagicString } from '@vue/compiler-sfc'
 
 import { findNode, parseSFC } from './utils'
 
+export async function transformPage(code: string, enabledGlobalRef = false) {
+  const sfc = await parseSFC(code)
+  const ms = new MagicString(code)
+
+  wrapTemplate(ms, sfc, 'global-ku-root', getPageRootRefSource(sfc, enabledGlobalRef))
+
+  return ms
+}
+
+export async function transformNvuePage(code: string, componentImportPath: string, enabledGlobalRef = false) {
+  const sfc = await parseSFC(code)
+  const ms = new MagicString(code)
+
+  wrapTemplate(ms, sfc, 'GlobalKuRoot', getPageRootRefSource(sfc, enabledGlobalRef))
+
+  if (sfc.scriptSetup) {
+    ms.appendLeft(sfc.scriptSetup.loc.start.offset, getNvueRootImport(componentImportPath))
+  }
+  else if (sfc.script) {
+    ms.appendLeft(sfc.script.loc.start.offset, getNvueRootImport(componentImportPath))
+    ensureNvueOptionsComponent(ms, sfc.script)
+  }
+  else {
+    ms.append(
+      `\n<script>\n${getNvueRootImport(componentImportPath)}export default {\n  components: { GlobalKuRoot },\n}\n</script>\n`,
+    )
+  }
+
+  return ms
+}
+
 function getPageRootRefSource(sfc: SFCDescriptor, enabledGlobalRef = false) {
   const pageTempAttrs = sfc.template?.attrs
   if (pageTempAttrs && pageTempAttrs.root) {
@@ -33,15 +64,6 @@ function wrapTemplate(ms: MagicString, sfc: SFCDescriptor, tagName: string, root
     ms.appendLeft(pageTempStart, `${pageMetaPrefix}<${tagName}${refSource}>`)
     ms.appendRight(pageTempEnd, `\n</${tagName}>\n`)
   }
-}
-
-export async function transformPage(code: string, enabledGlobalRef = false) {
-  const sfc = await parseSFC(code)
-  const ms = new MagicString(code)
-
-  wrapTemplate(ms, sfc, 'global-ku-root', getPageRootRefSource(sfc, enabledGlobalRef))
-
-  return ms
 }
 
 function getNvueRootImport(componentImportPath: string) {
@@ -85,26 +107,4 @@ function ensureNvueOptionsComponent(ms: MagicString, script: SFCScriptBlock) {
   }
 
   ms.appendLeft(script.loc.end.offset, '\nexport default {\n  components: { GlobalKuRoot },\n}\n')
-}
-
-export async function transformNvuePage(code: string, componentImportPath: string, enabledGlobalRef = false) {
-  const sfc = await parseSFC(code)
-  const ms = new MagicString(code)
-
-  wrapTemplate(ms, sfc, 'GlobalKuRoot', getPageRootRefSource(sfc, enabledGlobalRef))
-
-  if (sfc.scriptSetup) {
-    ms.appendLeft(sfc.scriptSetup.loc.start.offset, getNvueRootImport(componentImportPath))
-  }
-  else if (sfc.script) {
-    ms.appendLeft(sfc.script.loc.start.offset, getNvueRootImport(componentImportPath))
-    ensureNvueOptionsComponent(ms, sfc.script)
-  }
-  else {
-    ms.append(
-      `\n<script>\n${getNvueRootImport(componentImportPath)}export default {\n  components: { GlobalKuRoot },\n}\n</script>\n`,
-    )
-  }
-
-  return ms
 }

--- a/src/page.ts
+++ b/src/page.ts
@@ -1,11 +1,17 @@
+import type { SFCDescriptor, SFCScriptBlock } from '@vue/compiler-sfc'
 import { MagicString } from '@vue/compiler-sfc'
 
 import { findNode, parseSFC } from './utils'
 
-export async function transformPage(code: string, enabledGlobalRef = false) {
-  const sfc = await parseSFC(code)
-  const ms = new MagicString(code)
+function getPageRootRefSource(sfc: SFCDescriptor, enabledGlobalRef = false) {
+  const pageTempAttrs = sfc.template?.attrs
+  if (pageTempAttrs && pageTempAttrs.root) {
+    return `ref="${pageTempAttrs.root as string}"`
+  }
+  return enabledGlobalRef ? 'ref="uniKuRoot"' : ''
+}
 
+function wrapTemplate(ms: MagicString, sfc: SFCDescriptor, tagName: string, rootRefSource = '') {
   const pageTempStart = sfc.template?.loc.start.offset
   const pageTempEnd = sfc.template?.loc.end.offset
 
@@ -21,17 +27,83 @@ export async function transformPage(code: string, enabledGlobalRef = false) {
     ms.remove(metaTempStart, metaTempEnd)
   }
 
-  const pageTempAttrs = sfc.template?.attrs
+  if (pageTempStart != null && pageTempEnd != null) {
+    const refSource = rootRefSource ? ` ${rootRefSource}` : ''
+    const pageMetaPrefix = pageMetaSource ? `\n${pageMetaSource}\n` : '\n'
+    ms.appendLeft(pageTempStart, `${pageMetaPrefix}<${tagName}${refSource}>`)
+    ms.appendRight(pageTempEnd, `\n</${tagName}>\n`)
+  }
+}
 
-  let pageRootRefSource = enabledGlobalRef ? 'ref="uniKuRoot"' : ''
+export async function transformPage(code: string, enabledGlobalRef = false) {
+  const sfc = await parseSFC(code)
+  const ms = new MagicString(code)
 
-  if (pageTempAttrs && pageTempAttrs.root) {
-    pageRootRefSource = `ref="${pageTempAttrs.root as string}"`
+  wrapTemplate(ms, sfc, 'global-ku-root', getPageRootRefSource(sfc, enabledGlobalRef))
+
+  return ms
+}
+
+function getNvueRootImport(componentImportPath: string) {
+  return `import GlobalKuRoot from '${componentImportPath}'\n`
+}
+
+function findExportDefaultObjectStart(scriptContent: string) {
+  const exportDefaultIndex = scriptContent.indexOf('export default')
+  if (exportDefaultIndex < 0) {
+    return -1
   }
 
-  if (pageTempStart && pageTempEnd) {
-    ms.appendLeft(pageTempStart, `\n${pageMetaSource}\n<global-ku-root ${pageRootRefSource}>`)
-    ms.appendRight(pageTempEnd, `\n</global-ku-root>\n`)
+  const afterExportDefault = scriptContent.slice(exportDefaultIndex + 'export default'.length)
+  const defineComponentMatch = afterExportDefault.match(/^\s*defineComponent\s*\(\s*\{/)
+  if (defineComponentMatch) {
+    return exportDefaultIndex + 'export default'.length + defineComponentMatch[0].length
+  }
+
+  const objectMatch = afterExportDefault.match(/^\s*\{/)
+  if (objectMatch) {
+    return exportDefaultIndex + 'export default'.length + objectMatch[0].length
+  }
+
+  return -1
+}
+
+function ensureNvueOptionsComponent(ms: MagicString, script: SFCScriptBlock) {
+  const componentsMatch = script.content.match(/components\s*:\s*\{/)
+  if (componentsMatch && componentsMatch.index != null) {
+    ms.appendLeft(componentsMatch.index + componentsMatch[0].length, ' GlobalKuRoot,')
+    return
+  }
+
+  const exportDefaultObjectStart = findExportDefaultObjectStart(script.content)
+  if (exportDefaultObjectStart >= 0) {
+    ms.appendLeft(
+      exportDefaultObjectStart,
+      '\n  components: { GlobalKuRoot },',
+    )
+    return
+  }
+
+  ms.appendLeft(script.loc.end.offset, '\nexport default {\n  components: { GlobalKuRoot },\n}\n')
+}
+
+export async function transformNvuePage(code: string, componentImportPath: string, enabledGlobalRef = false) {
+  const sfc = await parseSFC(code)
+  const ms = new MagicString(code)
+
+  wrapTemplate(ms, sfc, 'GlobalKuRoot', getPageRootRefSource(sfc, enabledGlobalRef))
+
+  if (sfc.scriptSetup) {
+    ms.appendLeft(sfc.scriptSetup.loc.start.offset, getNvueRootImport(componentImportPath))
+  }
+  else if (sfc.script) {
+    ms.appendLeft(sfc.script.loc.start.offset, getNvueRootImport(componentImportPath))
+    ensureNvueOptionsComponent(ms, sfc.script)
+  }
+  else {
+    ms.append(
+      `\n<script>\n${getNvueRootImport(componentImportPath)}export default {\n  components: { GlobalKuRoot },\n}\n</script>\n`,
+    )
   }
 
   return ms

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,5 @@
 import type { SFCDescriptor } from '@vue/compiler-sfc'
-import { readFileSync } from 'node:fs'
+import { existsSync, readFileSync } from 'node:fs'
 import { extname, join } from 'node:path'
 import process from 'node:process'
 
@@ -18,8 +18,29 @@ export async function parseSFC(code: string): Promise<SFCDescriptor> {
   }
 }
 
+const PAGE_FILE_EXTS = ['.vue', '.nvue']
+
+export function formatPagePaths(root: string, path: string): string[] {
+  const joinedPath = join(root, path)
+  const pathExt = extname(joinedPath)
+
+  if (pathExt) {
+    return [normalizePath(joinedPath)]
+  }
+
+  const pageFilePaths = PAGE_FILE_EXTS
+    .map(fileExt => `${joinedPath}${fileExt}`)
+    .filter(filePath => existsSync(filePath))
+
+  if (pageFilePaths.length) {
+    return pageFilePaths.map(filePath => normalizePath(filePath))
+  }
+
+  return [normalizePath(`${joinedPath}.vue`)]
+}
+
 export function formatPagePath(root: string, path: string) {
-  return normalizePath(`${join(root, path)}.vue`)
+  return formatPagePaths(root, path)[0]
 }
 
 export function loadPagesJson(path: string, rootPath: string): string[] {
@@ -31,10 +52,10 @@ export function loadPagesJson(path: string, rootPath: string): string[] {
 
   return [
     ...pages
-      .map((page: any) => formatPagePath(rootPath, page.path)),
+      .flatMap((page: any) => formatPagePaths(rootPath, page.path)),
     ...subPackages
-      .map(({ pages = {}, root = '' }: any) => {
-        return pages.map((page: any) => formatPagePath(join(rootPath, root), page.path))
+      .map(({ pages = [], root = '' }: any) => {
+        return pages.flatMap((page: any) => formatPagePaths(join(rootPath, root), page.path))
       })
       .flat(),
   ]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
 import type { SFCDescriptor } from '@vue/compiler-sfc'
 import { existsSync, readFileSync } from 'node:fs'
-import { extname, join } from 'node:path'
+import { dirname, extname, join, relative } from 'node:path'
 import process from 'node:process'
 
 import { parse as VueParser } from '@vue/compiler-sfc'
@@ -43,7 +43,7 @@ export function formatPagePath(root: string, path: string) {
   return formatPagePaths(root, path)[0]
 }
 
-export function loadPagesJson(path: string, rootPath: string): string[] {
+export function loadPagePaths(path: string, rootPath: string): string[] {
   const pagesJsonRaw = readFileSync(path, 'utf-8')
 
   const pagesJson = jsonParse(pagesJsonRaw)
@@ -151,4 +151,9 @@ export function toArray<T>(value: T | T[]): T[] {
   }
 
   return Array.isArray(value) ? value : [value]
+}
+
+export function getRelativePath(fromFile: string, toFile: string) {
+  const importPath = normalizePath(relative(dirname(fromFile), toFile))
+  return importPath.startsWith('.') ? importPath : `./${importPath}`
 }

--- a/test/examples-nvue.test.ts
+++ b/test/examples-nvue.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { normalizePath } from 'vite'
+import { describe, expect, it } from 'vitest'
+
+import { transformNvuePage } from '../src/page'
+import { getRelativePath, loadPagePaths } from '../src/utils'
+
+const testDirectory = dirname(fileURLToPath(import.meta.url))
+const examplesSourceRoot = resolve(testDirectory, '../examples/src')
+const pagesJsonPath = join(examplesSourceRoot, 'pages.json')
+const appKuPath = join(examplesSourceRoot, 'KuRoot.vue')
+
+describe('examples nvue pages', () => {
+  it('resolves nvue demo pages from examples pages.json', () => {
+    const pagePaths = loadPagePaths(pagesJsonPath, examplesSourceRoot)
+
+    expect(pagePaths).toContain(normalizePath(join(examplesSourceRoot, 'pages/nvue-demo.nvue')))
+    expect(pagePaths).toContain(normalizePath(join(examplesSourceRoot, 'pages/nvue-options.nvue')))
+  })
+
+  it('wraps examples/src/pages/nvue-demo.nvue with a local GlobalKuRoot import', async () => {
+    const pagePath = join(examplesSourceRoot, 'pages/nvue-demo.nvue')
+    const sourceCode = readFileSync(pagePath, 'utf-8')
+    const rootImportPath = getRelativePath(pagePath, appKuPath)
+
+    const result = (await transformNvuePage(sourceCode, rootImportPath)).toString()
+
+    expect(rootImportPath).toBe('../KuRoot.vue')
+    expect(result).toContain(`import GlobalKuRoot from '${rootImportPath}'`)
+    expect(result).toContain('<GlobalKuRoot ref="uniKuRoot">')
+    expect(result).toContain('</GlobalKuRoot>')
+  })
+
+  it('registers GlobalKuRoot for examples/src/pages/nvue-options.nvue', async () => {
+    const pagePath = join(examplesSourceRoot, 'pages/nvue-options.nvue')
+    const sourceCode = readFileSync(pagePath, 'utf-8')
+    const rootImportPath = getRelativePath(pagePath, appKuPath)
+
+    const result = (await transformNvuePage(sourceCode, rootImportPath)).toString()
+
+    expect(result).toContain(`import GlobalKuRoot from '${rootImportPath}'`)
+    expect(result).toContain('components: { GlobalKuRoot },')
+    expect(result).toContain('<GlobalKuRoot ref="kuRoot">')
+    expect(result).toContain('</GlobalKuRoot>')
+  })
+})

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -1,22 +1,99 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { normalizePath } from 'vite'
 import { afterEach, describe, expect, it } from 'vitest'
 
+import { transformNvuePage, transformPage } from '../src/page'
 import { loadPagesJson } from '../src/utils'
 
-const tempDirectories: string[] = []
+const tempDirs: string[] = []
 
 afterEach(() => {
-  tempDirectories.splice(0).forEach(directory => rmSync(directory, { recursive: true, force: true }))
+  while (tempDirs.length) {
+    rmSync(tempDirs.pop()!, { recursive: true, force: true })
+  }
 })
 
-describe('loadPagesJson', () => {
+function createTempRoot() {
+  const rootPath = mkdtempSync(join(tmpdir(), 'uni-ku-root-'))
+  tempDirs.push(rootPath)
+  return rootPath
+}
+
+describe('page transforms', () => {
+  it('wraps vue pages and keeps page-meta above the root component', async () => {
+    const code = `<template root="rootRef">
+  <page-meta><navigation-bar title="Home" /></page-meta>
+  <view>Home</view>
+</template>
+`
+
+    const result = (await transformPage(code, true)).toString()
+
+    expect(result).toContain('<page-meta><navigation-bar title="Home" /></page-meta>\n<global-ku-root ref="rootRef">')
+    expect(result).toContain('\n</global-ku-root>\n</template>')
+    expect(result.match(/<page-meta>/g)).toHaveLength(1)
+  })
+
+  it('locally imports the root component for nvue script setup pages', async () => {
+    const code = `<template>
+  <view>NVUE</view>
+</template>
+
+<script setup lang="ts">
+const label = 'NVUE'
+</script>
+`
+
+    const result = (await transformNvuePage(code, '../App.ku.vue', true)).toString()
+
+    expect(result).toContain('<GlobalKuRoot ref="uniKuRoot">')
+    expect(result).toContain('\n</GlobalKuRoot>\n</template>')
+    expect(result).toContain('import GlobalKuRoot from \'../App.ku.vue\'\n\nconst label')
+  })
+
+  it('registers the local root component for nvue options api pages', async () => {
+    const code = `<template root="kuRoot">
+  <view>NVUE</view>
+</template>
+
+<script>
+export default {
+  components: { LocalThing },
+  data() {
+    return { label: 'NVUE' }
+  },
+}
+</script>
+`
+
+    const result = (await transformNvuePage(code, '../../App.ku.vue')).toString()
+
+    expect(result).toContain('import GlobalKuRoot from \'../../App.ku.vue\'')
+    expect(result).toContain('components: { GlobalKuRoot, LocalThing }')
+    expect(result).toContain('<GlobalKuRoot ref="kuRoot">')
+  })
+
+  it('adds an options api script when an nvue page has no script block', async () => {
+    const code = `<template>
+  <view>NVUE</view>
+</template>
+`
+
+    const result = (await transformNvuePage(code, './App.ku.vue')).toString()
+
+    expect(result).toContain('<GlobalKuRoot>')
+    expect(result).toContain('<script>\nimport GlobalKuRoot from \'./App.ku.vue\'')
+    expect(result).toContain('components: { GlobalKuRoot }')
+  })
+})
+
+describe('pages.json loading', () => {
   it.each(['subPackages', 'subpackages'])('loads pages from %s', (subPackagesKey) => {
-    const directory = mkdtempSync(join(tmpdir(), 'uni-ku-root-'))
-    const pagesJsonPath = join(directory, 'pages.json')
-    tempDirectories.push(directory)
+    const rootPath = createTempRoot()
+    const pagesJsonPath = join(rootPath, 'pages.json')
 
     writeFileSync(pagesJsonPath, JSON.stringify({
       pages: [{ path: 'pages/index' }],
@@ -29,6 +106,38 @@ describe('loadPagesJson', () => {
     expect(loadPagesJson(pagesJsonPath, '/project/src')).toEqual([
       '/project/src/pages/index.vue',
       '/project/src/packages/example/pages/detail.vue',
+    ])
+  })
+
+  it('matches existing vue and nvue files for extensionless page paths', () => {
+    const rootPath = createTempRoot()
+    mkdirSync(join(rootPath, 'pages'), { recursive: true })
+    mkdirSync(join(rootPath, 'pkg', 'sub'), { recursive: true })
+    writeFileSync(join(rootPath, 'pages', 'index.vue'), '')
+    writeFileSync(join(rootPath, 'pages', 'index.nvue'), '')
+    writeFileSync(join(rootPath, 'pkg', 'sub', 'profile.nvue'), '')
+    writeFileSync(join(rootPath, 'pages.json'), `{
+      "pages": [
+        { "path": "pages/index" },
+        { "path": "pages/about" }
+      ],
+      "subPackages": [
+        {
+          "root": "pkg",
+          "pages": [
+            { "path": "sub/profile" }
+          ]
+        }
+      ]
+    }`)
+
+    const pages = loadPagesJson(join(rootPath, 'pages.json'), rootPath)
+
+    expect(pages).toEqual([
+      normalizePath(join(rootPath, 'pages', 'index.vue')),
+      normalizePath(join(rootPath, 'pages', 'index.nvue')),
+      normalizePath(join(rootPath, 'pages', 'about.vue')),
+      normalizePath(join(rootPath, 'pkg', 'sub', 'profile.nvue')),
     ])
   })
 })

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -6,7 +6,7 @@ import { normalizePath } from 'vite'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { transformNvuePage, transformPage } from '../src/page'
-import { loadPagesJson } from '../src/utils'
+import { loadPagePaths } from '../src/utils'
 
 const tempDirs: string[] = []
 
@@ -103,7 +103,7 @@ describe('pages.json loading', () => {
       }],
     }))
 
-    expect(loadPagesJson(pagesJsonPath, '/project/src')).toEqual([
+    expect(loadPagePaths(pagesJsonPath, '/project/src')).toEqual([
       '/project/src/pages/index.vue',
       '/project/src/packages/example/pages/detail.vue',
     ])
@@ -131,7 +131,7 @@ describe('pages.json loading', () => {
       ]
     }`)
 
-    const pages = loadPagesJson(join(rootPath, 'pages.json'), rootPath)
+    const pages = loadPagePaths(join(rootPath, 'pages.json'), rootPath)
 
     expect(pages).toEqual([
       normalizePath(join(rootPath, 'pages', 'index.vue')),


### PR DESCRIPTION
## 变更说明

- 支持从 `pages.json` 识别并转换 `.nvue` 页面，未写扩展名时会同时匹配已存在的 `.vue` 与 `.nvue` 文件
- 为 nvue 页面本地导入并注册 `App.ku.vue`，避免依赖 nvue 不支持的全局组件注册
- 复用普通页面的模板包裹、`PageMeta` 提取、局部/全局 root ref 行为，并跳过 SFC 子块二次转换
- 补充 nvue 使用文档与 transform/page discovery 单元测试

## 验证

- `pnpm exec vitest run`
- `pnpm build`
- `pnpm exec eslint .`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced NVue page support by automatically applying the virtual root wrapper across both script setup and options API pages.
  - Improved page resolution from `pages.json`, including extensionless entries and mixed `.vue`/`.nvue` files within subpackages.
- **Bug Fixes**
  - Ensures NVue option pages correctly register the required virtual root component, even when script blocks are missing.
- **Documentation**
  - Updated documentation to reflect completion of NVue virtual root support.
- **Tests**
  - Added/extended coverage for NVue example pages and page-path resolution behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->