### PR TITLE
feat: 兼容 pages.json 中 subPackages 字段的小写形式

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,7 +25,9 @@ export function formatPagePath(root: string, path: string) {
 export function loadPagesJson(path: string, rootPath: string): string[] {
   const pagesJsonRaw = readFileSync(path, 'utf-8')
 
-  const { pages = [], subPackages = [] } = jsonParse(pagesJsonRaw)
+  const pagesJson = jsonParse(pagesJsonRaw)
+  const { pages = [] } = pagesJson
+  const subPackages = pagesJson.subPackages ?? pagesJson.subpackages ?? []
 
   return [
     ...pages

--- a/test/transform.test.ts
+++ b/test/transform.test.ts
@@ -1,0 +1,34 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { loadPagesJson } from '../src/utils'
+
+const tempDirectories: string[] = []
+
+afterEach(() => {
+  tempDirectories.splice(0).forEach(directory => rmSync(directory, { recursive: true, force: true }))
+})
+
+describe('loadPagesJson', () => {
+  it.each(['subPackages', 'subpackages'])('loads pages from %s', (subPackagesKey) => {
+    const directory = mkdtempSync(join(tmpdir(), 'uni-ku-root-'))
+    const pagesJsonPath = join(directory, 'pages.json')
+    tempDirectories.push(directory)
+
+    writeFileSync(pagesJsonPath, JSON.stringify({
+      pages: [{ path: 'pages/index' }],
+      [subPackagesKey]: [{
+        root: 'packages/example',
+        pages: [{ path: 'pages/detail' }],
+      }],
+    }))
+
+    expect(loadPagesJson(pagesJsonPath, '/project/src')).toEqual([
+      '/project/src/pages/index.vue',
+      '/project/src/packages/example/pages/detail.vue',
+    ])
+  })
+})


### PR DESCRIPTION
加载页面时同时识别 `subPackages` 和 `subpackages`，避免因字段命名差异导致子包页面未被处理。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved page configuration loading to recognize both `subPackages` and `subpackages` naming formats.
  - Added safer handling when no subpackage configuration is provided, preventing parsing issues and ensuring page paths resolve correctly.

- **Tests**
  - Added coverage for both supported subpackage property formats and verified resolution of associated page files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->